### PR TITLE
Use write_to_dataset instead of write_table

### DIFF
--- a/json2parquet/client.py
+++ b/json2parquet/client.py
@@ -104,7 +104,7 @@ def write_parquet(data, destination, **kwargs):
         table = pa.Table.from_batches(data)
     except TypeError:
         table = pa.Table.from_batches([data])
-    pq.write_table(table, destination, **kwargs)
+    pq.write_to_dataset(table, destination, **kwargs)
 
 
 def convert_json(input, output, schema, **kwargs):


### PR DESCRIPTION
write_to_dataset is a wrapper around write_table which allows to partition subdirectories by columns.

https://github.com/apache/arrow/blob/master/python/pyarrow/parquet.py#L987

example: Writing partition parquet files to s3
https://stackoverflow.com/questions/49085686/pyarrow-s3fs-partition-by-timetsamp