### PR TITLE
Make client.write_parquet_dataset available for export

### DIFF
--- a/json2parquet/__init__.py
+++ b/json2parquet/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from .client import load_json, ingest_data, write_parquet, convert_json
+from .client import load_json, ingest_data, write_parquet, convert_json, write_parquet_dataset
 
 __title__ = 'json2parquet'
 __version__ = '0.0.24'


### PR DESCRIPTION
This commit adds write_parquet_dataset to the imports from .client in
__init__.py

Previously, `from json2parquet import write_parquet_dataset` would
result in an error: `ImportError: cannot import name
'write_parquet_dataset' from 'json2parquet' `