### PR TITLE
remove version locks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     author_email='andrew.w.gross@gmail.com',
     url='https://github.com/andrewgross/json2parquet',
     install_requires=[
-        'pyarrow==0.14.0',
-        'pandas==0.24.2',
+        'pyarrow>=0.14.0',
+        'pandas>=0.24.2',
         'numpy>=1.14.0',
         'ciso8601'
     ],


### PR DESCRIPTION
- Allow later versions of `pyarrow` and `pandas`
- All tests pass
- Addresses https://github.com/andrewgross/json2parquet/issues/37